### PR TITLE
Changed mouseup listener to a click event so plugin would work with un…

### DIFF
--- a/src/ts/js-year-calendar.ts
+++ b/src/ts/js-year-calendar.ts
@@ -993,7 +993,7 @@ export default class Calendar<T extends CalendarDataSourceElement> {
 			contextMenu.style.top = (position.top + 25) + 'px';
 			contextMenu.style.display = 'block';
 			
-			window.addEventListener('mouseup', () => {
+			window.addEventListener('click', () => {
 				contextMenu.style.display = 'none';
 			}, { once: true });
 		}


### PR DESCRIPTION
This resolves issue 3 which I was able to reproduce on MacOS (10.14) and Debian (Ubuntu 18.04) type systems. When secondary clicking the context menu disappears when the click is let go. This makes the context menu unusable. I believe this had to do with the way the one method handles a mouse up event.

This issue was carried in from the bootstrap-year-calendar and hopefully, this resolves this it. I will need someone with a Windows machine to test that this does not break.