### PR TITLE
Allow usage of the calendar for specific periods

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,27 @@ document.querySelector('.calendar').addEventListener('clickDay', function(e) {
 
 You can find the exhaustive list of events in the [documentation](https://year-calendar.github.io/js-year-calendar/documentation).
 
+## Migrating v1.x to v2.x
+
+If you are using the dataSource option as a function (callback or promise), the first parameter has changed:
+```
+new Calendar('#calendar', {
+  dataSource: (year) => {
+    console.log(year);
+  }
+}
+```
+becomes
+```
+new Calendar('#calendar', {
+  dataSource: (period) => {
+    console.log(period.year);
+  }
+}
+```
+
+For more details, check [this PR](https://github.com/year-calendar/js-year-calendar/pull/32)
+
 ## Migrating from bootstrap-year-calendar
 
 This widget is based on the [bootstrap-year-calendar](https://github.com/Paul-DS/bootstrap-year-calendar) widget.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "js-year-calendar",
-  "version": "1.0.2",
+  "version": "2.0.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-year-calendar",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "description": "A fully customizable year calendar widget",
   "main": "./dist/js-year-calendar.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-year-calendar",
-  "version": "1.0.2-alpha.1",
+  "version": "2.0.0-alpha.1",
   "description": "A fully customizable year calendar widget",
   "main": "./dist/js-year-calendar.js",
   "scripts": {

--- a/src/ts/interfaces/CalendarOptions.ts
+++ b/src/ts/interfaces/CalendarOptions.ts
@@ -133,6 +133,7 @@ export default interface CalendarOptions<T extends CalendarDataSourceElement> {
 
     /**
      * The year on which the calendar should be opened.
+     * If `startDate` is provided, this option will be ignored.
      */
     startYear?: number;
 

--- a/src/ts/interfaces/CalendarOptions.ts
+++ b/src/ts/interfaces/CalendarOptions.ts
@@ -4,6 +4,7 @@ import CalendarDayEventObject from './CalendarDayEventObject'
 import CalendarRenderEndEventObject from './CalendarRenderEndEventObject'
 import CalendarRangeEventObject from './CalendarRangeEventObject'
 import CalendarYearChangedEventObject from './CalendarYearChangedEventObject'
+import CalendarPeriodChangedEventObject from './CalendarPeriodChangedEventObject'
 
 /**
  * Options used for calendar customization.
@@ -113,11 +114,22 @@ export default interface CalendarOptions<T extends CalendarDataSourceElement> {
      * The date from which days are enabled.
      */
     minDate?: Date;
+
+    /**
+     * The number of months displayed by the calendar.
+     */
+    numberMonthsDisplayed?: number;
 	
 	/**
      * Specifies whether the beginning and the end of each range should be displayed as rounded cells.
      */
     roundRangeLimits?: boolean;
+
+    /**
+     * The date on which the calendar should be opened.
+     * The day is not considered (only the month and the year).
+     */
+    startDate?: Date;
 
     /**
      * The year on which the calendar should be opened.
@@ -163,9 +175,14 @@ export default interface CalendarOptions<T extends CalendarDataSourceElement> {
      * Function fired when a date range is selected.
      */
     selectRange?: (e: CalendarRangeEventObject) => void;
-	
-	/**
+    
+    /**
      * Function fired when the visible year of the calendar is changed.
      */
     yearChanged?: (e: CalendarYearChangedEventObject) => void;
+
+	/**
+     * Function fired when the visible period of the calendar is changed.
+     */
+    periodChanged?: (e: CalendarPeriodChangedEventObject) => void;
 }

--- a/src/ts/interfaces/CalendarOptions.ts
+++ b/src/ts/interfaces/CalendarOptions.ts
@@ -179,6 +179,7 @@ export default interface CalendarOptions<T extends CalendarDataSourceElement> {
     
     /**
      * Function fired when the visible year of the calendar is changed.
+     * This function will be fired only if the calendar is used in a full year mode. Otherwise, use `periodChanged` event.
      */
     yearChanged?: (e: CalendarYearChangedEventObject) => void;
 

--- a/src/ts/interfaces/CalendarPeriodChangedEventObject.ts
+++ b/src/ts/interfaces/CalendarPeriodChangedEventObject.ts
@@ -1,0 +1,16 @@
+export default interface CalendarPeriodChangedEventObject {
+    /**
+     * The beginning of the new period.
+     */
+    startDate: Date;
+
+    /**
+     * The end of the new period.
+     */
+    endDate: Date;
+	
+	/**
+     * Indicates whether the automatic render after period changing must be prevented.
+     */
+    preventRendering: boolean;
+}

--- a/src/ts/js-year-calendar.ts
+++ b/src/ts/js-year-calendar.ts
@@ -1379,6 +1379,13 @@ export default class Calendar<T extends CalendarDataSourceElement> {
 	}
 
 	/**
+     * Gets the first date displayed on the calendar.
+     */
+	public getStartDate(): Date {
+		return this._startDate;
+	}
+
+	/**
      * Sets the first date that should be displayed on the calendar.
      *
      * @param startDate The first date that should be displayed on the calendar.
@@ -1418,6 +1425,32 @@ export default class Calendar<T extends CalendarDataSourceElement> {
 				if (!periodEventResult.preventRendering && (!yearEventResult || !yearEventResult.preventRedering)) {
 					this.render();
 				}
+			}
+		}
+	}
+
+	/**
+     * Gets the number of months displayed by the calendar.
+     */
+	public getNumberMonthsDisplayed(): number {
+		return this.options.numberMonthsDisplayed;
+	}
+
+	/**
+     * Sets the number of months displayed that should be displayed by the calendar.
+	 * 
+	 * This method causes a refresh of the calendar.
+     *
+     * @param numberMonthsDisplayed Number of months that should be displayed by the calendar.
+	 * @param preventRedering Indicates whether the rendering should be prevented after the property update.
+     */
+	public setNumberMonthsDisplayed(numberMonthsDisplayed: number | string, preventRendering: boolean = false): void {
+		var parsedNumber = parseInt(numberMonthsDisplayed as string);
+		if (!isNaN(parsedNumber) && parsedNumber > 0 && parsedNumber <= 12) {
+			this.options.numberMonthsDisplayed = parsedNumber;
+
+			if (!preventRendering) {
+				this.render();
 			}
 		}
 	}

--- a/src/ts/js-year-calendar.ts
+++ b/src/ts/js-year-calendar.ts
@@ -164,6 +164,7 @@ export default class Calendar<T extends CalendarDataSourceElement> {
 	
 	/**
 	 * Triggered after the changing the current year.
+	 * Works only if the calendar is used in a full year mode. Otherwise, use `periodChanged` event.
 	 * @event
 	 * @example
 	 * ```

--- a/src/ts/js-year-calendar.ts
+++ b/src/ts/js-year-calendar.ts
@@ -279,19 +279,25 @@ export default class Calendar<T extends CalendarDataSourceElement> {
 	protected _fetchDataSource(callback: (dataSource: T[]) => void) {
 		if (typeof this.options.dataSource === "function") {
 			const getDataSource:any = this.options.dataSource;
+			const currentPeriod = this.getCurrentPeriod();
+			const fetchParameters = {
+				year: currentPeriod.startDate.getFullYear(),
+				startDate: currentPeriod.startDate,
+				endDate: currentPeriod.endDate,
+			};
 
 			if (getDataSource.length == 2) {
 				// 2 parameters, means callback method
-				getDataSource(this.options.startYear, callback);
+				getDataSource(fetchParameters, callback);
 			}
 			else {
 				// 1 parameter, means synchronous or promise method
-				var result = getDataSource(this.options.startYear);
+				var result = getDataSource(fetchParameters);
 
 				if (result instanceof Array) {
 					callback(result);
 				}
-				else {
+				if (result && result.then) {
 					result.then(callback);
 				}
 			}

--- a/src/ts/js-year-calendar.ts
+++ b/src/ts/js-year-calendar.ts
@@ -348,7 +348,12 @@ export default class Calendar<T extends CalendarDataSourceElement> {
 				setTimeout(() => months.style.transition = '', 500);
 			}, 0);
 			
-			this._triggerEvent('renderEnd', { currentYear: this.options.startYear });
+			const currentPeriod = this.getCurrentPeriod();
+			this._triggerEvent('renderEnd', {
+				currentYear: currentPeriod.startDate.getFullYear(),
+				startDate: currentPeriod.startDate,
+				endDate: currentPeriod.endDate
+			});
 		}
 	}
 

--- a/src/ts/js-year-calendar.ts
+++ b/src/ts/js-year-calendar.ts
@@ -1358,6 +1358,7 @@ export default class Calendar<T extends CalendarDataSourceElement> {
 
 	/**
      * Gets the year displayed on the calendar.
+	 * If the calendar is not used in a full year configuration, this will return the year of the first date displayed in the calendar.
      */
 	public getYear(): number | null {
 		return this._isFullYearMode() ? this._startDate.getFullYear() : null;
@@ -1365,6 +1366,7 @@ export default class Calendar<T extends CalendarDataSourceElement> {
 
 	/**
      * Sets the year displayed on the calendar.
+	 * If the calendar is not used in a full year configuration, this will set the start date to January 1st of the given year.
      *
      * @param year The year to displayed on the calendar.
      */

--- a/src/ts/js-year-calendar.ts
+++ b/src/ts/js-year-calendar.ts
@@ -1376,9 +1376,9 @@ export default class Calendar<T extends CalendarDataSourceElement> {
 	}
 
 	/**
-     * Sets the year displayed on the calendar.
+     * Sets the first date that should be displayed on the calendar.
      *
-     * @param year The year to displayed on the calendar.
+     * @param startDate The first date that should be displayed on the calendar.
      */
 	public setStartDate(startDate: Date): void {
 		if (startDate instanceof Date) {

--- a/src/ts/js-year-calendar.ts
+++ b/src/ts/js-year-calendar.ts
@@ -406,10 +406,8 @@ export default class Calendar<T extends CalendarDataSourceElement> {
 			yearDiv.textContent = `${period.startDate.getFullYear()} - ${(period.endDate.getFullYear())}`;
 		}
 		else if (this.options.numberMonthsDisplayed > 1) {
-			yearDiv.textContent = `
-				${Calendar.locales[this.options.language].months[period.startDate.getMonth()]} ${period.startDate.getFullYear()}
-				 - ${Calendar.locales[this.options.language].months[period.endDate.getMonth()]} ${period.endDate.getFullYear()}
-			`;
+			yearDiv.textContent = 
+				`${Calendar.locales[this.options.language].months[period.startDate.getMonth()]} ${period.startDate.getFullYear()} - ${Calendar.locales[this.options.language].months[period.endDate.getMonth()]} ${period.endDate.getFullYear()}`;
 		}
 		else {
 			yearDiv.textContent = `${Calendar.locales[this.options.language].months[period.startDate.getMonth()]} ${period.startDate.getFullYear()}`;
@@ -1351,7 +1349,7 @@ export default class Calendar<T extends CalendarDataSourceElement> {
      * Gets the year displayed on the calendar.
      */
 	public getYear(): number | null {
-		return this._isFullYearMode() ? this.options.startYear : null;
+		return this._isFullYearMode() ? this._startDate.getFullYear() : null;
 	}
 
 	/**
@@ -1380,7 +1378,7 @@ export default class Calendar<T extends CalendarDataSourceElement> {
 			while (this.element.firstChild) {
 				this.element.removeChild(this.element.firstChild);
 			}
-		
+
 			if (this.options.displayHeader) {
 				this._renderHeader();
 			}

--- a/tests/events.js
+++ b/tests/events.js
@@ -69,19 +69,23 @@ test('mouse out day event', () => {
 });
 
 test('render end event', () => {
-    const renderEndInit = jest.fn(e => ({ calendar: e.calendar, currentYear: e.currentYear }));
-    const renderEndAdded = jest.fn(e => ({ calendar: e.calendar, currentYear: e.currentYear }));
+    const renderEndInit = jest.fn(e => ({ calendar: e.calendar, currentYear: e.currentYear, startDate: e.startDate, endDate: e.endDate }));
+    const renderEndAdded = jest.fn(e => ({ calendar: e.calendar, currentYear: e.currentYear, startDate: e.startDate, endDate: e.endDate }));
 
     document.querySelector('#calendar').addEventListener('renderEnd', renderEndAdded);
     const calendar = new Calendar('#calendar', { renderEnd: renderEndInit });
 
     calendar.setYear(2000);
 
-    expect(renderEndInit).toHaveNthReturnedWith(1, { calendar, currentYear });
-    expect(renderEndAdded).toHaveNthReturnedWith(1, { calendar, currentYear });
+    let endDate = new Date(currentYear + 1, 0, 1);
+    endDate.setTime(endDate.getTime() - 1);
+    expect(renderEndInit).toHaveNthReturnedWith(1, { calendar, currentYear, startDate: new Date(currentYear, 0, 1), endDate: endDate });
+    expect(renderEndAdded).toHaveNthReturnedWith(1, { calendar, currentYear, startDate: new Date(currentYear, 0, 1), endDate: endDate });
 
-    expect(renderEndInit).toHaveNthReturnedWith(2, { calendar, currentYear: 2000 });
-    expect(renderEndAdded).toHaveNthReturnedWith(2, { calendar, currentYear: 2000 });
+    endDate = new Date(2001, 0, 1);
+    endDate.setTime(endDate.getTime() - 1);
+    expect(renderEndInit).toHaveNthReturnedWith(2, { calendar, currentYear: 2000, startDate: new Date(2000, 0, 1), endDate: endDate });
+    expect(renderEndAdded).toHaveNthReturnedWith(2, { calendar, currentYear: 2000, startDate: new Date(2000, 0, 1), endDate: endDate });
 });
 
 

--- a/tests/initialization.js
+++ b/tests/initialization.js
@@ -48,10 +48,36 @@ test('instantiate calendar with other', () => {
     expect(() => new Calendar(null)).toThrow();
 });
 
+test('instantiate calendar with start date', () => {
+    const calendar = new Calendar('#calendar', { startDate: new Date(2000, 5, 1) });
+  
+    expect(document.querySelectorAll('#calendar .year-title').length).toEqual(1);
+    expect(document.querySelector('#calendar .year-title').textContent).toEqual("2000 - 2001");
+    expect(document.querySelectorAll('#calendar .month').length).toEqual(12);
+});
+
+test('instantiate calendar with start date and number months displayed', () => {
+    const calendar = new Calendar('#calendar', { startDate: new Date(2000, 10, 1), numberMonthsDisplayed: 3 });
+  
+    expect(document.querySelectorAll('#calendar .year-title').length).toEqual(1);
+    expect(document.querySelector('#calendar .year-title').textContent).toEqual("November 2000 - January 2001");
+    expect(document.querySelectorAll('#calendar .month').length).toEqual(3);
+});
+
+test('instantiate calendar with start date and single month displayed', () => {
+    const calendar = new Calendar('#calendar', { startDate: new Date(2000, 5, 1), numberMonthsDisplayed: 1 });
+  
+    expect(document.querySelectorAll('#calendar .year-title').length).toEqual(1);
+    expect(document.querySelector('#calendar .year-title').textContent).toEqual("June 2000");
+    expect(document.querySelectorAll('#calendar .month').length).toEqual(1);
+});
+
 test('instantiate calendar with start year', () => {
     const calendar = new Calendar('#calendar', { startYear: 2000 });
   
+    expect(document.querySelectorAll('#calendar .year-title').length).toEqual(5);
     expect(document.querySelector('#calendar .year-title:not(.year-neighbor):not(.year-neighbor2').textContent).toEqual("2000");
+    expect(document.querySelectorAll('#calendar .month').length).toEqual(12);
 });
 
 test('instantiate calendar with min date', () => {

--- a/tests/initialization.js
+++ b/tests/initialization.js
@@ -292,10 +292,10 @@ test('instantiate calendar with display disabled data source', () => {
 });
 
 test('instantiate calendar with data source function', () => {
-    const dataSource = jest.fn(year => [
+    const dataSource = jest.fn(period => [
         {
-            startDate: new Date(year, 6, year - 2000),
-            endDate: new Date(year, 6, year - 2000)
+            startDate: new Date(period.year, 6, period.year - 2000),
+            endDate: new Date(period.year, 6, period.year - 2000)
         }
     ]);
 
@@ -305,23 +305,58 @@ test('instantiate calendar with data source function', () => {
     });
     
     expect(dataSource).toHaveBeenCalledTimes(1);
-    expect(dataSource).toHaveBeenLastCalledWith(2001);
+    
+    let endDate = new Date(2002, 0, 1);
+    endDate.setTime(endDate.getTime() - 1);
+    expect(dataSource).toHaveBeenLastCalledWith({ year: 2001, startDate: new Date(2001, 0, 1), endDate });
     expect(getDay(6, 1).style.boxShadow).toBeTruthy();
     expect(getDay(6, 2).style.boxShadow).toBeFalsy();
     
     calendar.setYear(2002);
     expect(dataSource).toHaveBeenCalledTimes(2);
-    expect(dataSource).toHaveBeenLastCalledWith(2002);
+    endDate.setFullYear(2002);
+    expect(dataSource).toHaveBeenLastCalledWith({ year: 2002, startDate: new Date(2002, 0, 1), endDate });
     expect(getDay(6, 1).style.boxShadow).toBeFalsy();
     expect(getDay(6, 2).style.boxShadow).toBeTruthy();
 });
 
+test('instantiate calendar with data source function and custom period', () => {
+    const dataSource = jest.fn(period => [
+        {
+            startDate: new Date(period.startDate.getFullYear(), period.startDate.getMonth(), period.startDate.getMonth()),
+            endDate: new Date(period.startDate.getFullYear(), period.startDate.getMonth(), period.startDate.getMonth()),
+        }
+    ]);
+
+    const calendar = new Calendar('#calendar', {
+        startDate: new Date(2001, 2, 1),
+        numberMonthsDisplayed: 2,
+		dataSource: dataSource
+    });
+    
+    expect(dataSource).toHaveBeenCalledTimes(1);
+    
+    let endDate = new Date(2001, 4, 1);
+    endDate.setTime(endDate.getTime() - 1);
+    expect(dataSource).toHaveBeenLastCalledWith({ year: 2001, startDate: new Date(2001, 2, 1), endDate });
+    expect(getDay(0, 2).style.boxShadow).toBeTruthy();
+    expect(getDay(0, 6).style.boxShadow).toBeFalsy();
+    
+    calendar.setStartDate(new Date(2001, 6, 1));
+    expect(dataSource).toHaveBeenCalledTimes(2);
+    endDate = new Date(2001, 8, 1);
+    endDate.setTime(endDate.getTime() - 1);
+    expect(dataSource).toHaveBeenLastCalledWith({ year: 2001, startDate: new Date(2001, 6, 1), endDate });
+    expect(getDay(0, 2).style.boxShadow).toBeFalsy();
+    expect(getDay(0, 6).style.boxShadow).toBeTruthy();
+});
+
 test('instantiate calendar with data source callback function', () => {
-    const dataSource = jest.fn((year, callback) => {
+    const dataSource = jest.fn((period, callback) => {
         callback([
             {
-                startDate: new Date(year, 6, year - 2000),
-                endDate: new Date(year, 6, year - 2000)
+                startDate: new Date(period.year, 6, period.year - 2000),
+                endDate: new Date(period.year, 6, period.year - 2000)
             }
         ]);
     });
@@ -342,11 +377,11 @@ test('instantiate calendar with data source callback function', () => {
 });
 
 test('instantiate calendar with data source promise function', done => {
-    const dataSource = jest.fn(year => new Promise((resolve, reject) => {
+    const dataSource = jest.fn(period => new Promise((resolve, reject) => {
         resolve([
             {
-                startDate: new Date(year, 6, year - 2000),
-                endDate: new Date(year, 6, year - 2000)
+                startDate: new Date(period.year, 6, period.year - 2000),
+                endDate: new Date(period.year, 6, period.year - 2000)
             }
         ]);
     }));
@@ -357,7 +392,9 @@ test('instantiate calendar with data source promise function', done => {
     });
 
     expect(dataSource).toHaveBeenCalledTimes(1);
-    expect(dataSource).toHaveBeenLastCalledWith(2001);
+    const endDate = new Date(2002, 0, 1);
+    endDate.setTime(endDate.getTime() - 1);
+    expect(dataSource).toHaveBeenLastCalledWith({ year: 2001, startDate: new Date(2001, 0, 1), endDate });
 
     setTimeout(() => {
         expect(getDay(6, 1).style.boxShadow).toBeTruthy();
@@ -365,7 +402,8 @@ test('instantiate calendar with data source promise function', done => {
         
         calendar.setYear(2002);
         expect(dataSource).toHaveBeenCalledTimes(2);
-        expect(dataSource).toHaveBeenLastCalledWith(2002);
+        endDate.setFullYear(2002);
+        expect(dataSource).toHaveBeenLastCalledWith({ year: 2002, startDate: new Date(2002, 0, 1), endDate });
 
         setTimeout(() => {
             expect(getDay(6, 1).style.boxShadow).toBeFalsy();

--- a/tests/methods.js
+++ b/tests/methods.js
@@ -92,7 +92,9 @@ test('get / set datasource method', () => {
     expect(calendar.getDataSource()).toEqual(dataSource);
 
     expect(dataSource).toHaveBeenCalledTimes(1);
-    expect(dataSource).toHaveBeenLastCalledWith(currentYear);
+    const endDate = new Date(currentYear + 1, 0, 1);
+    endDate.setTime(endDate.getTime() - 1);
+    expect(dataSource).toHaveBeenLastCalledWith({ year: currentYear, startDate: new Date(currentYear, 0, 1), endDate });
 });
 
 test('get / set disabled days method', () => {


### PR DESCRIPTION
Following the requests for this 2 features:
- Display only X months in the calendar (#26, Paul-DS/bootstrap-year-calendar#19, Paul-DS/bootstrap-year-calendar#101, Paul-DS/bootstrap-year-calendar#120)
- Change the starting month of the calendar (#30, Paul-DS/bootstrap-year-calendar#18, Paul-DS/bootstrap-year-calendar#43, Paul-DS/bootstrap-year-calendar#60)

This PR implement 2 options:
- `startDate`: Allow to define the first month displayed in the calendar
- `numberMonthsDisplayed` Allow to define the number of months displayed in the calendar

# Examples

These options allow you to do the following:

## Display a full year starting from a specific month

With parameters:
- `startDate: new Date(2020, 8, 1)`

Result:
![image](https://user-images.githubusercontent.com/15329946/78452939-cb82c500-768e-11ea-979b-c9e4ab6da39f.png)

## Display only X months

With parameters:
- `numberMonthsDisplayed: 3`

Result:
![image](https://user-images.githubusercontent.com/15329946/78452989-2ae0d500-768f-11ea-8e32-8d60625638f8.png)

With parameters:
- `startDate: new Date(2020, 3, 1)`
- `numberMonthsDisplayed: 1`

Result:
![image](https://user-images.githubusercontent.com/15329946/78453025-6b405300-768f-11ea-9e55-27e0c2e6956b.png)

# TODO

- [x] Update the `dataSource` option to pass the `startDate` and `endDate` parameters
- [x] Update the comments to specify the order of priority between `startDate` and `startYear`
- [x] Update the comments to specify the condition of usage of `yearChanged` event, the `getYear`/`setYear` methods, etc...
- [ ] Test all functionalities to unsure there is no regression
- [x] Add specific unit tests

# Breaking changes :warning:

The first parameter of the dataSource function is now `{ year, startDate, endDate }` instead of just `year`.

Example:
```
new Calendar('#calendar', {
    dataSource: function(period) {
        console.log(`Year: ${period.year}`);
        console.log(`Period displayed: ${period.startDate} - ${period.endDate}`);
        return ...;
    }
});
```

# How to test

Use the `@next` version of the package:
- With NPM: `npm install js-year-calendar@next`
- With CDN: `<script src="https://unpkg.com/js-year-calendar@next/dist/js-year-calendar.min.js"></script>`


# Additional informations

This is an additional feature , so it shouldn't break the current usage of the calendar (using the basic option`startYear`).

The `startDate` option override the `startYear` option.
The `yearChanged` event, and the `getYear` and `setYear` method are available only if the `startDate` and `numberMonthsDisplayed` options are not used.
