### PR TITLE
avoiding undesired falsy case in weekStart option check

### DIFF
--- a/src/ts/js-year-calendar.ts
+++ b/src/ts/js-year-calendar.ts
@@ -446,7 +446,7 @@ export default class Calendar<T extends CalendarDataSourceElement> {
 				headerRow.appendChild(weekNumberCell);
 			}
 			
-			var weekStart = this.options.weekStart ? this.options.weekStart : Calendar.locales[this.options.language].weekStart;
+			var weekStart = !isNaN(this.options.weekStart) ? this.options.weekStart : Calendar.locales[this.options.language].weekStart;
 			var d = weekStart;
 			do
 			{
@@ -1766,7 +1766,7 @@ export default class Calendar<T extends CalendarDataSourceElement> {
      * Gets the starting day of the week.
      */
 	public getWeekStart(): number {
-		return this.options.weekStart ? this.options.weekStart : Calendar.locales[this.options.language].weekStart;
+		return !isNaN(this.options.weekStart) ? this.options.weekStart : Calendar.locales[this.options.language].weekStart;
 	}
 
 	/**

--- a/src/ts/js-year-calendar.ts
+++ b/src/ts/js-year-calendar.ts
@@ -446,7 +446,7 @@ export default class Calendar<T extends CalendarDataSourceElement> {
 				headerRow.appendChild(weekNumberCell);
 			}
 			
-			var weekStart = !isNaN(this.options.weekStart) ? this.options.weekStart : Calendar.locales[this.options.language].weekStart;
+			var weekStart = this.getWeekStart();
 			var d = weekStart;
 			do
 			{
@@ -1766,7 +1766,7 @@ export default class Calendar<T extends CalendarDataSourceElement> {
      * Gets the starting day of the week.
      */
 	public getWeekStart(): number {
-		return !isNaN(this.options.weekStart) ? this.options.weekStart : Calendar.locales[this.options.language].weekStart;
+		return this.options.weekStart !== null ? this.options.weekStart : Calendar.locales[this.options.language].weekStart;
 	}
 
 	/**


### PR DESCRIPTION
Sorry, but it doesn't appear to be letting me to link to the issue, or I'm just not seeing it (go me!)
Here it is: https://github.com/year-calendar/js-year-calendar/issues/57