### PR TITLE
fix: only publish required files to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,0 @@
-node_modules

--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
     "build",
     "test"
   ],
+  "files": [
+    "dist",
+    "locales"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/year-calendar/js-year-calendar.git"


### PR DESCRIPTION
Right now just about every file is published to npm, which makes the tarball ridiculously large and having way more files than it needs.

**Before this change (also viewable on [unpkg](https://unpkg.com/browse/js-year-calendar@1.0.2/)**
<details>
<summary> Click here to expand </summary>


```
npm notice package: js-year-calendar@1.0.2
npm notice === Tarball Contents ===
npm notice 221B    .babelrc
npm notice 11.6kB  LICENSE
npm notice 5.4kB   coverage/lcov-report/base.css
npm notice 7.4kB   dist/js-year-calendar.css
npm notice 5.4kB   dist/js-year-calendar.min.css
npm notice 71.3kB  docs/assets/css/main.css
npm notice 676B    coverage/lcov-report/prettify.css
npm notice 4.3kB   docs/modules/__global.html
npm notice 5.6kB   docs/interfaces/__global.window.html
npm notice 133.3kB docs/classes/calendar.html
npm notice 12.2kB  docs/interfaces/calendarcontextmenuitem.html
npm notice 13.2kB  docs/interfaces/calendardatasourceelement.html
npm notice 9.4kB   docs/interfaces/calendardayeventobject.html
npm notice 59.2kB  docs/interfaces/calendaroptions.html
npm notice 8.0kB   docs/interfaces/calendarrangeeventobject.html
npm notice 7.0kB   docs/interfaces/calendarrenderendeventobject.html
npm notice 8.2kB   docs/interfaces/calendaryearchangedeventobject.html
npm notice 7.2kB   docs/globals.html
npm notice 4.3kB   coverage/lcov-report/dist/index.html
npm notice 4.9kB   coverage/lcov-report/index.html
npm notice 23.4kB  coverage/lcov-report/locales/index.html
npm notice 16.1kB  docs/index.html
npm notice 5.1kB   coverage/lcov-report/locales/js-year-calendar.ca.js.html
npm notice 5.2kB   coverage/lcov-report/locales/js-year-calendar.cs.js.html
npm notice 5.1kB   coverage/lcov-report/locales/js-year-calendar.de.js.html
npm notice 5.1kB   coverage/lcov-report/locales/js-year-calendar.es.js.html
npm notice 5.0kB   coverage/lcov-report/locales/js-year-calendar.eu.js.html
npm notice 4.9kB   coverage/lcov-report/locales/js-year-calendar.fi.js.html
npm notice 5.1kB   coverage/lcov-report/locales/js-year-calendar.fr.js.html
npm notice 4.7kB   coverage/lcov-report/locales/js-year-calendar.hr.js.html
npm notice 5.1kB   coverage/lcov-report/locales/js-year-calendar.hu.js.html
npm notice 5.1kB   coverage/lcov-report/locales/js-year-calendar.id.js.html
npm notice 5.1kB   coverage/lcov-report/locales/js-year-calendar.is.js.html
npm notice 5.1kB   coverage/lcov-report/locales/js-year-calendar.it.js.html
npm notice 5.1kB   coverage/lcov-report/locales/js-year-calendar.ja.js.html
npm notice 281.0kB coverage/lcov-report/dist/js-year-calendar.js.html
npm notice 5.0kB   coverage/lcov-report/locales/js-year-calendar.lt.js.html
npm notice 4.7kB   coverage/lcov-report/locales/js-year-calendar.lv.js.html
npm notice 5.1kB   coverage/lcov-report/locales/js-year-calendar.nl.js.html
npm notice 4.7kB   coverage/lcov-report/locales/js-year-calendar.pl.js.html
npm notice 5.2kB   coverage/lcov-report/locales/js-year-calendar.pt.js.html
npm notice 5.3kB   coverage/lcov-report/locales/js-year-calendar.ru.js.html
npm notice 4.8kB   coverage/lcov-report/locales/js-year-calendar.sk.js.html
npm notice 4.9kB   coverage/lcov-report/locales/js-year-calendar.sr.js.html
npm notice 5.2kB   coverage/lcov-report/locales/js-year-calendar.th.js.html
npm notice 5.1kB   coverage/lcov-report/locales/js-year-calendar.tr.js.html
npm notice 5.0kB   coverage/lcov-report/locales/js-year-calendar.ua.js.html
npm notice 4.9kB   coverage/lcov-report/locales/js-year-calendar.uk.js.html
npm notice 5.1kB   coverage/lcov-report/locales/js-year-calendar.uz.js.html
npm notice 5.2kB   coverage/lcov-report/locales/js-year-calendar.zh-CN.js.html
npm notice 5.2kB   coverage/lcov-report/locales/js-year-calendar.zh-TW.js.html
npm notice 26.6kB  coverage/lcov.info
npm notice 6.7kB   tests/actions.js
npm notice 439B    tests/auto-init.js
npm notice 2.4kB   coverage/lcov-report/block-navigation.js
npm notice 5.0kB   tests/events.js
npm notice 1.4kB   gulpfile.js
npm notice 12.1kB  tests/initialization.js
npm notice 701B    locales/js-year-calendar.ca.js
npm notice 755B    locales/js-year-calendar.cs.js
npm notice 683B    locales/js-year-calendar.de.js
npm notice 696B    locales/js-year-calendar.es.js
npm notice 719B    locales/js-year-calendar.eu.js
npm notice 663B    locales/js-year-calendar.fi.js
npm notice 680B    locales/js-year-calendar.fr.js
npm notice 625B    locales/js-year-calendar.hr.js
npm notice 737B    locales/js-year-calendar.hu.js
npm notice 688B    locales/js-year-calendar.id.js
npm notice 743B    locales/js-year-calendar.is.js
npm notice 702B    locales/js-year-calendar.it.js
npm notice 689B    locales/js-year-calendar.ja.js
npm notice 72.1kB  dist/js-year-calendar.js
npm notice 752B    locales/js-year-calendar.lt.js
npm notice 614B    locales/js-year-calendar.lv.js
npm notice 29.9kB  dist/js-year-calendar.min.js
npm notice 688B    locales/js-year-calendar.nl.js
npm notice 612B    locales/js-year-calendar.pl.js
npm notice 749B    locales/js-year-calendar.pt.js
npm notice 886B    locales/js-year-calendar.ru.js
npm notice 607B    locales/js-year-calendar.sk.js
npm notice 787B    locales/js-year-calendar.sr.js
npm notice 939B    locales/js-year-calendar.th.js
npm notice 695B    locales/js-year-calendar.tr.js
npm notice 790B    locales/js-year-calendar.ua.js
npm notice 796B    locales/js-year-calendar.uk.js
npm notice 619B    locales/js-year-calendar.uz.js
npm notice 773B    locales/js-year-calendar.zh-CN.js
npm notice 790B    locales/js-year-calendar.zh-TW.js
npm notice 967B    tests/locales.js
npm notice 50.0kB  docs/assets/js/main.js
npm notice 12.4kB  tests/methods.js
npm notice 17.6kB  coverage/lcov-report/prettify.js
npm notice 12.3kB  docs/assets/js/search.js
npm notice 5.3kB   coverage/lcov-report/sorter.js
npm notice 180.7kB coverage/coverage-final.json
npm notice 1.6kB   package.json
npm notice 136B    tsconfig.json
npm notice 6.4kB   src/less/js-year-calendar.less
npm notice 5.5kB   README.md
npm notice 540B    coverage/lcov-report/favicon.png
npm notice 9.6kB   docs/assets/images/icons.png
npm notice 28.1kB  docs/assets/images/icons@2x.png
npm notice 209B    coverage/lcov-report/sort-arrow-sprite.png
npm notice 480B    docs/assets/images/widgets.png
npm notice 855B    docs/assets/images/widgets@2x.png
npm notice 476B    dist/interfaces/CalendarContextMenuItem.d.ts
npm notice 506B    src/ts/interfaces/CalendarContextMenuItem.ts
npm notice 801B    dist/interfaces/CalendarDataSourceElement.d.ts
npm notice 834B    src/ts/interfaces/CalendarDataSourceElement.ts
npm notice 393B    dist/interfaces/CalendarDayEventObject.d.ts
npm notice 409B    src/ts/interfaces/CalendarDayEventObject.ts
npm notice 5.0kB   dist/interfaces/CalendarOptions.d.ts
npm notice 5.2kB   src/ts/interfaces/CalendarOptions.ts
npm notice 208B    dist/interfaces/CalendarRangeEventObject.d.ts
npm notice 218B    src/ts/interfaces/CalendarRangeEventObject.ts
npm notice 125B    dist/interfaces/CalendarRenderEndEventObject.d.ts
npm notice 129B    src/ts/interfaces/CalendarRenderEndEventObject.ts
npm notice 254B    dist/interfaces/CalendarYearChangedEventObject.d.ts
npm notice 262B    src/ts/interfaces/CalendarYearChangedEventObject.ts
npm notice 18.5kB  dist/js-year-calendar.d.ts
npm notice 59.1kB  src/ts/js-year-calendar.ts
npm notice 53.2kB  coverage/clover.xml
npm notice 375B    .circleci/config.yml
npm notice === Tarball Details ===
npm notice name:          js-year-calendar
npm notice version:       1.0.2
npm notice package size:  231.0 kB
npm notice unpacked size: 1.5 MB
npm notice shasum:        bd3499ab78d24dc8a026022513d5f0355a160fdc
npm notice integrity:     sha512-oFA+0oFUWmLPk[...]gAzB3n/OqepmA==
npm notice total files:   123
npm notice
+ js-year-calendar@1.0.2
```

</details>


**After this change**
<details>
<summary> Click here to expand </summary>

```
npm notice package: js-year-calendar@1.0.2
npm notice === Tarball Contents ===
npm notice 11.6kB LICENSE
npm notice 7.4kB  dist/js-year-calendar.css
npm notice 5.4kB  dist/js-year-calendar.min.css
npm notice 701B   locales/js-year-calendar.ca.js
npm notice 755B   locales/js-year-calendar.cs.js
npm notice 683B   locales/js-year-calendar.de.js
npm notice 696B   locales/js-year-calendar.es.js
npm notice 719B   locales/js-year-calendar.eu.js
npm notice 663B   locales/js-year-calendar.fi.js
npm notice 680B   locales/js-year-calendar.fr.js
npm notice 625B   locales/js-year-calendar.hr.js
npm notice 737B   locales/js-year-calendar.hu.js
npm notice 688B   locales/js-year-calendar.id.js
npm notice 743B   locales/js-year-calendar.is.js
npm notice 702B   locales/js-year-calendar.it.js
npm notice 689B   locales/js-year-calendar.ja.js
npm notice 72.1kB dist/js-year-calendar.js
npm notice 752B   locales/js-year-calendar.lt.js
npm notice 614B   locales/js-year-calendar.lv.js
npm notice 29.9kB dist/js-year-calendar.min.js
npm notice 688B   locales/js-year-calendar.nl.js
npm notice 612B   locales/js-year-calendar.pl.js
npm notice 749B   locales/js-year-calendar.pt.js
npm notice 886B   locales/js-year-calendar.ru.js
npm notice 607B   locales/js-year-calendar.sk.js
npm notice 787B   locales/js-year-calendar.sr.js
npm notice 939B   locales/js-year-calendar.th.js
npm notice 695B   locales/js-year-calendar.tr.js
npm notice 790B   locales/js-year-calendar.ua.js
npm notice 796B   locales/js-year-calendar.uk.js
npm notice 619B   locales/js-year-calendar.uz.js
npm notice 773B   locales/js-year-calendar.zh-CN.js
npm notice 790B   locales/js-year-calendar.zh-TW.js
npm notice 1.6kB  package.json
npm notice 5.5kB  README.md
npm notice 476B   dist/interfaces/CalendarContextMenuItem.d.ts
npm notice 801B   dist/interfaces/CalendarDataSourceElement.d.ts
npm notice 393B   dist/interfaces/CalendarDayEventObject.d.ts
npm notice 5.0kB  dist/interfaces/CalendarOptions.d.ts
npm notice 208B   dist/interfaces/CalendarRangeEventObject.d.ts
npm notice 125B   dist/interfaces/CalendarRenderEndEventObject.d.ts
npm notice 254B   dist/interfaces/CalendarYearChangedEventObject.d.ts
npm notice 18.5kB dist/js-year-calendar.d.ts
npm notice === Tarball Details ===
npm notice name:          js-year-calendar
npm notice version:       1.0.2
npm notice package size:  37.7 kB
npm notice unpacked size: 179.4 kB
npm notice shasum:        acbd242087ce2b188853b41d0c9edb3cbc20e457
npm notice integrity:     sha512-nzvGJS6fC2O1Z[...]Yts0/0XuylmyA==
npm notice total files:   43
npm notice
+ js-year-calendar@1.0.2
```

</details>